### PR TITLE
Update VC Primer reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,7 +421,7 @@ to the concept of Decentralized Identifiers.
     subjects, and verifiers. More generally, DIDs can be used as
     identifiers for people, devices, and organizations.</p>
     <p>See the <a href=
-    "verifiable-credentials-primer.md"><em>Verifiable Credentials
+    "https://w3c.github.io/webpayments-ig/VCTF/primer/"><em>Verifiable Credentials
     Primer</em></a> for a brief introduction to the topic.</p>
   </section>
   <section>


### PR DESCRIPTION
Fixed the reference to the Verifiable Credentials Primer to https://w3c.github.io/webpayments-ig/VCTF/primer/